### PR TITLE
Accept Salad Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,5 +171,5 @@ dist
 .dev.vars
 .wrangler/
 
-wrangler.toml
+wrangler*.toml
 logs.txt

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.4",
       "dependencies": {
         "@cloudflare/itty-router-openapi": "^1.0.10",
-        "jose": "^6.0.11",
+        "jose": "5.9.6",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -58,19 +58,35 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.3.2.tgz",
+      "integrity": "sha512-MtUgNl+QkQyhQvv5bbWP+BpBC1N0me4CHHuP2H4ktmOMKdB/6kkz/lo+zqiA4mEazb4y+1cwyNjVrQ2DWeE4mg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.17",
+        "workerd": "^1.20250508.0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@cloudflare/vitest-pool-workers": {
-      "version": "0.8.32",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.8.32.tgz",
-      "integrity": "sha512-mV4Wvq5MVXY41Qog8O2hTjYt5E4L6A4CEQIIflqOhuR7H3rHL9vj4/pATzmthBxQtyYgwPavdBEf21ARwX9WuA==",
+      "version": "0.8.36",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.8.36.tgz",
+      "integrity": "sha512-aJ3IP+kMv3ButnQLyfG7ZVWNa2+nPE2w2ds0PHxNPW73JIjm2Hz1fcieWD+mJT/JdxdbERXuRkI3VedJ90magw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "birpc": "0.2.14",
         "cjs-module-lexer": "^1.2.3",
         "devalue": "^4.3.0",
-        "miniflare": "4.20250508.3",
+        "miniflare": "4.20250525.1",
         "semver": "^7.7.1",
-        "wrangler": "4.16.1",
+        "wrangler": "4.19.1",
         "zod": "^3.22.3"
       },
       "peerDependencies": {
@@ -80,9 +96,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20250508.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250508.0.tgz",
-      "integrity": "sha512-9x09MrA9Y5RQs3zqWvWns8xHgM2pVNXWpeJ+3hQYu4PrwPFZXtTD6b/iMmOnlYKzINlREq1RGeEybMFyWEUlUg==",
+      "version": "1.20250525.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250525.0.tgz",
+      "integrity": "sha512-L5l+7sSJJT2+riR5rS3Q3PKNNySPjWfRIeaNGMVRi1dPO6QPi4lwuxfRUFNoeUdilZJUVPfSZvTtj9RedsKznQ==",
       "cpu": [
         "x64"
       ],
@@ -97,9 +113,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20250508.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250508.0.tgz",
-      "integrity": "sha512-0Ili+nE2LLRzYue/yPc1pepSyNNg6LxR3/ng/rlQzVQUxPXIXldHFkJ/ynsYwQnAcf6OxasSi/kbTm6yvDoSAQ==",
+      "version": "1.20250525.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250525.0.tgz",
+      "integrity": "sha512-Y3IbIdrF/vJWh/WBvshwcSyUh175VAiLRW7963S1dXChrZ1N5wuKGQm9xY69cIGVtitpMJWWW3jLq7J/Xxwm0Q==",
       "cpu": [
         "arm64"
       ],
@@ -114,9 +130,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20250508.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250508.0.tgz",
-      "integrity": "sha512-5saVrZ3uVwYxvBa7BaonXjeqB6X0YF3ak05qvBaWcmZ3FNmnarMm2W8842cnbhnckDVBpB/iDo51Sy6Y7y1jcw==",
+      "version": "1.20250525.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250525.0.tgz",
+      "integrity": "sha512-KSyQPAby+c6cpENoO0ayCQlY6QIh28l/+QID7VC1SLXfiNHy+hPNsH1vVBTST6CilHVAQSsy9tCZ9O9XECB8yg==",
       "cpu": [
         "x64"
       ],
@@ -131,9 +147,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20250508.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250508.0.tgz",
-      "integrity": "sha512-muQe1pkxRi3eaq1Q417xvfGd2SlktbLTzNhT5Yftsx8OecWrYuB8i4ttR6Nr5ER06bfEj0FqQjqJJhcp6wLLUQ==",
+      "version": "1.20250525.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250525.0.tgz",
+      "integrity": "sha512-Nt0FUxS2kQhJUea4hMCNPaetkrAFDhPnNX/ntwcqVlGgnGt75iaAhupWJbU0GB+gIWlKeuClUUnDZqKbicoKyg==",
       "cpu": [
         "arm64"
       ],
@@ -148,9 +164,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20250508.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250508.0.tgz",
-      "integrity": "sha512-EJj8iTWFMqjgvZUxxNvzK7frA1JMFi3y/9eDIdZPL/OaQh3cmk5Lai5DCXsKYUxfooMBZWYTp53zOLrvuJI8VQ==",
+      "version": "1.20250525.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250525.0.tgz",
+      "integrity": "sha512-mwTj+9f3uIa4NEXR1cOa82PjLa6dbrb3J+KCVJFYIaq7e63VxEzOchCXS4tublT2pmOhmFqkgBMXrxozxNkR2Q==",
       "cpu": [
         "x64"
       ],
@@ -165,9 +181,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20250524.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250524.0.tgz",
-      "integrity": "sha512-Tc/N/5nn3Jq+w7s+QPEgiyBZ0F0ebH9XWQ6YiUZTue79E7nybYDGh4lBCr2y4bC+RYiOP8KZPYWr811Hd3Oh2A==",
+      "version": "4.20250604.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250604.0.tgz",
+      "integrity": "sha512-//sQvI1x8wfd23o41QLF3z1Kj2ULAoUJ59zhIOCNjRRyaVoed/vtSVGo3porvTHXWz7C6E5f3duquCfElIqzKQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -185,9 +201,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.1.tgz",
-      "integrity": "sha512-LMshMVP0ZhACNjQNYXiU1iZJ6QCcv0lUdPDPugqGvCGXt5xtRVBPdtA0qU12pEXZzpWAhWlZYptfdAFq10DOVQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
+      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -196,9 +212,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.4.tgz",
-      "integrity": "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
+      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
       "cpu": [
         "ppc64"
       ],
@@ -208,14 +224,15 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.4.tgz",
-      "integrity": "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
+      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
       "cpu": [
         "arm"
       ],
@@ -225,14 +242,15 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.4.tgz",
-      "integrity": "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
+      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
       "cpu": [
         "arm64"
       ],
@@ -242,14 +260,15 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.4.tgz",
-      "integrity": "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
+      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
       "cpu": [
         "x64"
       ],
@@ -259,14 +278,15 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.4.tgz",
-      "integrity": "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
+      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
       "cpu": [
         "arm64"
       ],
@@ -276,14 +296,15 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.4.tgz",
-      "integrity": "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
+      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
       "cpu": [
         "x64"
       ],
@@ -293,14 +314,15 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.4.tgz",
-      "integrity": "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
       "cpu": [
         "arm64"
       ],
@@ -310,14 +332,15 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.4.tgz",
-      "integrity": "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
+      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
       "cpu": [
         "x64"
       ],
@@ -327,14 +350,15 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.4.tgz",
-      "integrity": "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
+      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
       "cpu": [
         "arm"
       ],
@@ -344,14 +368,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.4.tgz",
-      "integrity": "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
+      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
       "cpu": [
         "arm64"
       ],
@@ -361,14 +386,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.4.tgz",
-      "integrity": "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
+      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
       "cpu": [
         "ia32"
       ],
@@ -378,14 +404,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.4.tgz",
-      "integrity": "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
+      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
       "cpu": [
         "loong64"
       ],
@@ -395,14 +422,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.4.tgz",
-      "integrity": "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
+      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
       "cpu": [
         "mips64el"
       ],
@@ -412,14 +440,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.4.tgz",
-      "integrity": "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
+      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
       "cpu": [
         "ppc64"
       ],
@@ -429,14 +458,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.4.tgz",
-      "integrity": "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
+      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
       "cpu": [
         "riscv64"
       ],
@@ -446,14 +476,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.4.tgz",
-      "integrity": "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
+      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
       "cpu": [
         "s390x"
       ],
@@ -463,14 +494,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.4.tgz",
-      "integrity": "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
+      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
       "cpu": [
         "x64"
       ],
@@ -480,14 +512,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.4.tgz",
-      "integrity": "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
       "cpu": [
         "arm64"
       ],
@@ -497,14 +530,15 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.4.tgz",
-      "integrity": "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
+      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
       "cpu": [
         "x64"
       ],
@@ -514,14 +548,15 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.4.tgz",
-      "integrity": "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
       "cpu": [
         "arm64"
       ],
@@ -531,14 +566,15 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.4.tgz",
-      "integrity": "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
+      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
       "cpu": [
         "x64"
       ],
@@ -548,14 +584,15 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.4.tgz",
-      "integrity": "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
+      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
       "cpu": [
         "x64"
       ],
@@ -565,14 +602,15 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.4.tgz",
-      "integrity": "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
+      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
       "cpu": [
         "arm64"
       ],
@@ -582,14 +620,15 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.4.tgz",
-      "integrity": "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
+      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
       "cpu": [
         "ia32"
       ],
@@ -599,14 +638,15 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz",
-      "integrity": "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
+      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
       "cpu": [
         "x64"
       ],
@@ -616,6 +656,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1347,9 +1388,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "20.17.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
-      "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
+      "version": "20.17.57",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
+      "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1690,9 +1731,9 @@
       "license": "MIT"
     },
     "node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1715,12 +1756,13 @@
       "peer": true
     },
     "node_modules/esbuild": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.4.tgz",
-      "integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
+      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1728,31 +1770,31 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.4",
-        "@esbuild/android-arm": "0.25.4",
-        "@esbuild/android-arm64": "0.25.4",
-        "@esbuild/android-x64": "0.25.4",
-        "@esbuild/darwin-arm64": "0.25.4",
-        "@esbuild/darwin-x64": "0.25.4",
-        "@esbuild/freebsd-arm64": "0.25.4",
-        "@esbuild/freebsd-x64": "0.25.4",
-        "@esbuild/linux-arm": "0.25.4",
-        "@esbuild/linux-arm64": "0.25.4",
-        "@esbuild/linux-ia32": "0.25.4",
-        "@esbuild/linux-loong64": "0.25.4",
-        "@esbuild/linux-mips64el": "0.25.4",
-        "@esbuild/linux-ppc64": "0.25.4",
-        "@esbuild/linux-riscv64": "0.25.4",
-        "@esbuild/linux-s390x": "0.25.4",
-        "@esbuild/linux-x64": "0.25.4",
-        "@esbuild/netbsd-arm64": "0.25.4",
-        "@esbuild/netbsd-x64": "0.25.4",
-        "@esbuild/openbsd-arm64": "0.25.4",
-        "@esbuild/openbsd-x64": "0.25.4",
-        "@esbuild/sunos-x64": "0.25.4",
-        "@esbuild/win32-arm64": "0.25.4",
-        "@esbuild/win32-ia32": "0.25.4",
-        "@esbuild/win32-x64": "0.25.4"
+        "@esbuild/aix-ppc64": "0.25.5",
+        "@esbuild/android-arm": "0.25.5",
+        "@esbuild/android-arm64": "0.25.5",
+        "@esbuild/android-x64": "0.25.5",
+        "@esbuild/darwin-arm64": "0.25.5",
+        "@esbuild/darwin-x64": "0.25.5",
+        "@esbuild/freebsd-arm64": "0.25.5",
+        "@esbuild/freebsd-x64": "0.25.5",
+        "@esbuild/linux-arm": "0.25.5",
+        "@esbuild/linux-arm64": "0.25.5",
+        "@esbuild/linux-ia32": "0.25.5",
+        "@esbuild/linux-loong64": "0.25.5",
+        "@esbuild/linux-mips64el": "0.25.5",
+        "@esbuild/linux-ppc64": "0.25.5",
+        "@esbuild/linux-riscv64": "0.25.5",
+        "@esbuild/linux-s390x": "0.25.5",
+        "@esbuild/linux-x64": "0.25.5",
+        "@esbuild/netbsd-arm64": "0.25.5",
+        "@esbuild/netbsd-x64": "0.25.5",
+        "@esbuild/openbsd-arm64": "0.25.5",
+        "@esbuild/openbsd-x64": "0.25.5",
+        "@esbuild/sunos-x64": "0.25.5",
+        "@esbuild/win32-arm64": "0.25.5",
+        "@esbuild/win32-ia32": "0.25.5",
+        "@esbuild/win32-x64": "0.25.5"
       }
     },
     "node_modules/estree-walker": {
@@ -1798,9 +1840,9 @@
       "license": "MIT"
     },
     "node_modules/fdir": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
-      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
+      "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1860,9 +1902,9 @@
       "license": "MIT"
     },
     "node_modules/jose": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
-      "integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
+      "version": "5.9.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
+      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -1913,9 +1955,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20250508.3",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250508.3.tgz",
-      "integrity": "sha512-43oTmZ0CCmUcieetI5YDDyX0IiwhOcVIWzdBBCqWXK3F1XgQwg4d3fTqRyJnCmHIoaYx9CE1kTEKZC1UahPQhA==",
+      "version": "4.20250525.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250525.1.tgz",
+      "integrity": "sha512-4PJlT5WA+hfclFU5Q7xnpG1G1VGYTXaf/3iu6iKQ8IsbSi9QvPTA2bSZ5goCFxmJXDjV4cxttVxB0Wl1CLuQ0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1927,7 +1969,7 @@
         "sharp": "^0.33.5",
         "stoppable": "1.1.0",
         "undici": "^5.28.5",
-        "workerd": "1.20250508.0",
+        "workerd": "1.20250525.0",
         "ws": "8.18.0",
         "youch": "3.3.4",
         "zod": "3.22.3"
@@ -2051,9 +2093,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
+      "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
       "dev": true,
       "funding": [
         {
@@ -2072,7 +2114,7 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2129,9 +2171,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2275,9 +2317,9 @@
       "peer": true
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2293,9 +2335,9 @@
       }
     },
     "node_modules/tinypool": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
-      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.0.tgz",
+      "integrity": "sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2579,9 +2621,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20250508.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250508.0.tgz",
-      "integrity": "sha512-ffLxe7dXSuGoA6jb3Qx2SClIV1aLHfJQ6RhGhzYHjQgv7dL6fdUOSIIGgzmu2mRKs+WFSujp6c8WgKquco6w3w==",
+      "version": "1.20250525.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250525.0.tgz",
+      "integrity": "sha512-SXJgLREy/Aqw2J71Oah0Pbu+SShbqbTExjVQyRBTM1r7MG7fS5NUlknhnt6sikjA/t4cO09Bi8OJqHdTkrcnYQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -2592,17 +2634,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20250508.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20250508.0",
-        "@cloudflare/workerd-linux-64": "1.20250508.0",
-        "@cloudflare/workerd-linux-arm64": "1.20250508.0",
-        "@cloudflare/workerd-windows-64": "1.20250508.0"
+        "@cloudflare/workerd-darwin-64": "1.20250525.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250525.0",
+        "@cloudflare/workerd-linux-64": "1.20250525.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250525.0",
+        "@cloudflare/workerd-windows-64": "1.20250525.0"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.16.1.tgz",
-      "integrity": "sha512-YiLdWXcaQva2K/bqokpsZbySPmoT8TJFyJPsQPZumnkgimM9+/g/yoXArByA+pf+xU8jhw7ybQ8X1yBGXv731g==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.19.1.tgz",
+      "integrity": "sha512-b+ed2SJKauHgndl4Im1wHE+FeSSlrdlEZNuvpc8q/94k4EmRxRkXnwBAsVWuicBxG3HStFLQPGGlvL8wGKTtHw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -2610,10 +2652,10 @@
         "@cloudflare/unenv-preset": "2.3.2",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.25.4",
-        "miniflare": "4.20250508.3",
+        "miniflare": "4.20250525.1",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.17",
-        "workerd": "1.20250508.0"
+        "workerd": "1.20250525.0"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -2623,11 +2665,10 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.2",
-        "sharp": "^0.33.5"
+        "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20250508.0"
+        "@cloudflare/workers-types": "^4.20250525.0"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -2635,20 +2676,470 @@
         }
       }
     },
-    "node_modules/wrangler/node_modules/@cloudflare/unenv-preset": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.3.2.tgz",
-      "integrity": "sha512-MtUgNl+QkQyhQvv5bbWP+BpBC1N0me4CHHuP2H4ktmOMKdB/6kkz/lo+zqiA4mEazb4y+1cwyNjVrQ2DWeE4mg==",
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.4.tgz",
+      "integrity": "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==",
+      "cpu": [
+        "ppc64"
+      ],
       "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peerDependencies": {
-        "unenv": "2.0.0-rc.17",
-        "workerd": "^1.20250508.0"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.4.tgz",
+      "integrity": "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.4.tgz",
+      "integrity": "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.4.tgz",
+      "integrity": "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.4.tgz",
+      "integrity": "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.4.tgz",
+      "integrity": "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.4.tgz",
+      "integrity": "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.4.tgz",
+      "integrity": "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.4.tgz",
+      "integrity": "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.4.tgz",
+      "integrity": "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.4.tgz",
+      "integrity": "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.4.tgz",
+      "integrity": "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.4.tgz",
+      "integrity": "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.4.tgz",
+      "integrity": "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.4.tgz",
+      "integrity": "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.4.tgz",
+      "integrity": "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.4.tgz",
+      "integrity": "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.4.tgz",
+      "integrity": "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.4.tgz",
+      "integrity": "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.4.tgz",
+      "integrity": "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.4.tgz",
+      "integrity": "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.4.tgz",
+      "integrity": "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.4.tgz",
+      "integrity": "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.4.tgz",
+      "integrity": "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz",
+      "integrity": "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.4.tgz",
+      "integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
       },
-      "peerDependenciesMeta": {
-        "workerd": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.4",
+        "@esbuild/android-arm": "0.25.4",
+        "@esbuild/android-arm64": "0.25.4",
+        "@esbuild/android-x64": "0.25.4",
+        "@esbuild/darwin-arm64": "0.25.4",
+        "@esbuild/darwin-x64": "0.25.4",
+        "@esbuild/freebsd-arm64": "0.25.4",
+        "@esbuild/freebsd-x64": "0.25.4",
+        "@esbuild/linux-arm": "0.25.4",
+        "@esbuild/linux-arm64": "0.25.4",
+        "@esbuild/linux-ia32": "0.25.4",
+        "@esbuild/linux-loong64": "0.25.4",
+        "@esbuild/linux-mips64el": "0.25.4",
+        "@esbuild/linux-ppc64": "0.25.4",
+        "@esbuild/linux-riscv64": "0.25.4",
+        "@esbuild/linux-s390x": "0.25.4",
+        "@esbuild/linux-x64": "0.25.4",
+        "@esbuild/netbsd-arm64": "0.25.4",
+        "@esbuild/netbsd-x64": "0.25.4",
+        "@esbuild/openbsd-arm64": "0.25.4",
+        "@esbuild/openbsd-x64": "0.25.4",
+        "@esbuild/sunos-x64": "0.25.4",
+        "@esbuild/win32-arm64": "0.25.4",
+        "@esbuild/win32-ia32": "0.25.4",
+        "@esbuild/win32-x64": "0.25.4"
       }
     },
     "node_modules/ws": {
@@ -2674,15 +3165,15 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
       }
     },
     "node_modules/youch": {
@@ -2698,9 +3189,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "3.25.51",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.51.tgz",
+      "integrity": "sha512-TQSnBldh+XSGL+opiSIq0575wvDPqu09AqWe1F7JhUMKY+M91/aGlK4MhpVNO7MgYfHcVCB1ffwAUTJzllKJqg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.6.4",
       "dependencies": {
         "@cloudflare/itty-router-openapi": "^1.0.10",
+        "jose": "^6.0.11",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -1857,6 +1858,15 @@
       "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-4.0.26.tgz",
       "integrity": "sha512-GBcmhxQRvIQ7fuzXPlvfeQcN6O7VGhctzdG9WHIcEcaRYH4FvDpMxuSWRIAxQrIM+nxtfxK0/bR78ATvb4LC5Q==",
       "license": "MIT"
+    },
+    "node_modules/jose": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
+      "integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@cloudflare/itty-router-openapi": "^1.0.10",
-    "jose": "^6.0.11",
+    "jose": "5.10.0",
     "zod": "^3.22.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",
-    "start": "wrangler dev",
+    "start": "wrangler -c wrangler.dev.toml dev",
     "test": "vitest run --no-file-parallelism"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@cloudflare/itty-router-openapi": "^1.0.10",
+    "jose": "^6.0.11",
     "zod": "^3.22.4"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -509,10 +509,11 @@ All query parameters for this endpoint are optional.
 3. Once it receives a job, kelpie downloads anything in `.sync.before`.
 4. Once required files are downloaded, kelpie executes your command with the provided arguments, adding environment variables as documented above.
 5. Whenever files are added to a directory configured in `.sync.during`, kelpie syncs the directory to the checkpoint bucket and prefix.
-6. When your command exits 0, the job is marked as complete, and a webhook is sent (if configured) to notify you about the job's completion.
+6. While the job is running, kelpie will periodically send a heartbeat to the API to indicate that the job is still running. This is used to detect if the job has been interrupted or failed, as well as to tell the worker if the job has been canceled.
+7. When your command exits 0, the job is marked as complete, and a webhook is sent (if configured) to notify you about the job's completion.
    1. If your job has a `.sync.after` configured, kelpie will upload the contents of that directory to the configured bucket and prefix before marking the job as complete.
    2. If your job fails, meaning exits non-0, it will be reported as a failure to the api. When this occurs, the number of failures for the job is incremented, up to 3. The machine id reporting the failure will be blocked from receiving that job again. If the job fails 3 times, it is marked failed, and a webhook is sent, if configured. If a machine id is blocked from 5 jobs, the container will be reallocated to a different machine, provided you have added the kelpie user to your salad org.
-7. All configured directories in `.sync` are wiped out to reset for the next job.
+8. All configured directories in `.sync` are wiped out to reset for the next job.
 
 ## Status Webhooks
 

--- a/setup-db.sh
+++ b/setup-db.sh
@@ -15,7 +15,7 @@ for file in ./schemas/*.sql; do
     npx wrangler d1 execute kelpie $d1_env --file=$file
 done
 
-npx wrangler kv:key put $admin_token "00000000-0000-0000-0000-000000000000|<ROOT>|<ROOT>" --binding user_tokens $kv_env
+npx wrangler kv key put $admin_token "00000000-0000-0000-0000-000000000000|<ROOT>|<ROOT>" --binding user_tokens $kv_env
 
 echo "==Admin token=="
 echo "$admin_token"

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -1,11 +1,23 @@
 import { Env, DBUser } from '../types';
 
+/**
+ * Create a new user in the database.
+ * @param env The environment object.
+ * @param username The username of the new user.
+ * @returns The ID of the newly created user.
+ */
 export async function createUser(env: Env, username: string): Promise<string> {
 	const id = crypto.randomUUID();
 	await env.DB.prepare('INSERT INTO Users (id, username) VALUES (?, ?)').bind(id, username).run();
 	return id;
 }
 
+/**
+ * Update the username of an existing user.
+ * @param env The environment object.
+ * @param id The ID of the user to update.
+ * @param username The new username for the user.
+ */
 export async function getUserById(env: Env, id: string): Promise<DBUser | null> {
 	const { results } = await env.DB.prepare('SELECT * FROM Users WHERE id = ?').bind(id).all();
 	if (!results.length) {
@@ -14,6 +26,12 @@ export async function getUserById(env: Env, id: string): Promise<DBUser | null> 
 	return results[0] as unknown as DBUser;
 }
 
+/**
+ * Get a user by their username.
+ * @param env The environment object.
+ * @param username The username of the user to retrieve.
+ * @returns The user object, or null if not found.
+ */
 export async function getUserByUsername(env: Env, username: string): Promise<DBUser | null> {
 	const { results } = await env.DB.prepare('SELECT id FROM Users WHERE username = ?').bind(username).all();
 	if (!results.length) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ const router = OpenAPIRouter({
 		info: {
 			title: '🐕 Kelpie API',
 			description: 'API for running long jobs on Salad',
-			version: '0.6.0',
+			version: '0.6.4',
 		},
 	},
 });
@@ -86,6 +86,7 @@ class CatchAll extends OpenAPIRoute {
 	static schema = {
 		summary: 'Catch All',
 		description: 'Catch all for unmatched routes',
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		responses: {
 			'404': {
 				description: 'Not Found',

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,16 @@ router.registry.registerComponent('securitySchemes', 'apiKey', {
 	in: 'header',
 	name: 'X-Kelpie-Key',
 });
+router.registry.registerComponent('securitySchemes', 'saladApiKey', {
+	type: 'apiKey',
+	in: 'header',
+	name: 'Salad-Api-Key',
+});
+router.registry.registerComponent('securitySchemes', 'jwt', {
+	type: 'http',
+	scheme: 'bearer',
+	bearerFormat: 'JWT',
+});
 
 router.post('/jobs', CreateJob);
 router.post('/jobs/batch', BatchCreateJobs);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
 	ListJobs,
 	ClearJobs,
 } from './routes/jobs';
-import { CreateUser, CreateToken, ClearUsers } from './routes/users';
+import { CreateUser, CreateToken, ClearUsers, GetUser } from './routes/users';
 import {
 	CreateScalingRule,
 	UpdateScalingRule,
@@ -73,6 +73,8 @@ router.patch('/scaling-rules/:id', UpdateScalingRule);
 router.get('/scaling-rules', ListScalingRules);
 router.get('/scaling-rules/:id', GetScalingRule);
 router.delete('/scaling-rules/:id', DeleteScalingRule);
+
+router.get('/users/me', GetUser);
 
 router.delete('/jobs', adminOnly, ClearJobs);
 router.post('/users', adminOnly, CreateUser);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,20 +1,136 @@
-import { Env, AuthedRequest } from './types';
+import { Env, AuthedRequest, ApiKeyValidationResponse, SaladJWTPayload } from './types';
 import { error } from './utils/error';
+import * as jose from 'jose';
+import { listContainerGroups } from './utils/salad';
+import { createUser, getUserByUsername } from './db/users';
 
 export async function validateAuth(req: AuthedRequest, env: Env) {
-	const token = req.headers.get(env.API_HEADER);
-	if (!token) {
-		return error(401, { error: 'Unauthorized', message: 'API Key required' });
-	}
-	let idAndOrg = await env.user_tokens.get(token);
-	if (!idAndOrg) {
-		return error(403, { error: 'Forbidden', message: 'Invalid API Key' });
-	}
-	const [id, org, project] = idAndOrg.split('|');
-	req.userId = id;
-	req.saladOrg = org;
-	req.saladProject = project;
+	const kelpieApiKey = req.headers.get(env.API_HEADER);
+	const saladApiKey = req.headers.get('Salad-Api-Key');
+	const saladOrg = req.headers.get('Salad-Organization-Name');
+	const saladProject = req.headers.get('Salad-Project-Name');
+	const authHeader = req.headers.get('Authorization');
 
+	if (saladApiKey && (!saladOrg || !saladProject)) {
+		return error(400, { error: 'Bad Request', message: 'Salad API Key requires Salad-Organization-Name and Salad-Project-Name headers' });
+	} else if (authHeader && !saladProject) {
+		return error(400, { error: 'Bad Request', message: 'Bearer Token requires Salad-Project-Name header' });
+	}
+
+	if (kelpieApiKey) {
+		/**
+		 * This remains for backwards compatibility with the old API Key system.
+		 */
+		let idAndOrg = await env.user_tokens.get(kelpieApiKey);
+		if (!idAndOrg) {
+			return error(403, { error: 'Forbidden', message: 'Invalid API Key' });
+		}
+		const [id, org, project] = idAndOrg.split('|');
+		req.userId = id;
+		req.saladOrg = org;
+		req.saladProject = project;
+	} else if (saladApiKey && saladOrg && saladProject) {
+		/**
+		 * If a user includes a Salad API Key, we check if we have a cached user ID and organization.
+		 */
+		let idAndOrg = await env.user_tokens.get(`${saladApiKey}|${saladProject}`);
+		if (idAndOrg) {
+			const [id, org, project] = idAndOrg.split('|');
+			req.userId = id;
+			req.saladOrg = org;
+			req.saladProject = project;
+		} else {
+			/**
+			 * If we don't have a cached user ID, we need to validate the API Key.
+			 */
+			try {
+				const payload = await validateSaladApiKey(env, saladApiKey, saladOrg || '');
+				req.saladOrg = payload.organization_name;
+				payload.organization_id;
+				try {
+					await listContainerGroups(env, req.saladOrg, saladProject, true);
+					req.saladProject = saladProject;
+					/**
+					 * If everything is valid, we check to see if we have a user provisioned for this org already.
+					 */
+					const user = await getUserByUsername(env, req.saladOrg);
+					let userId: string | undefined;
+					if (!user) {
+						/**
+						 * If we don't have a user, we create one.
+						 */
+						userId = await createUser(env, req.saladOrg);
+					} else {
+						userId = user.id;
+					}
+					req.userId = userId;
+					/**
+					 * Finally, we cache the user ID and organization for future requests. This token expires
+					 * so that we have to revalidate the API Key periodically.
+					 */
+					await env.user_tokens.put(`${saladApiKey}|${saladProject}`, `${userId}|${req.saladOrg}|${saladProject}`, {
+						expirationTtl: parseInt(env.TOKEN_CACHE_TTL),
+					});
+				} catch (err: any) {
+					return error(403, { error: 'Forbidden', message: `Invalid Project '${saladProject}': ${err.message}` });
+				}
+			} catch (err: any) {
+				return error(403, { error: 'Forbidden', message: err.message });
+			}
+		}
+	} else if (authHeader && authHeader.startsWith('Bearer ') && saladProject) {
+		const [, imdsJwt] = authHeader.split(' ');
+		try {
+			/**
+			 * If a user includes a Bearer Token, we validate the JWT and extract the organization and workload ID.
+			 */
+			const payload = await validateSaladJWT(env, imdsJwt);
+			req.saladOrg = payload.salad_organization_name;
+
+			/**
+			 * We check if we have a cached user ID and organization for the workload ID and organization.
+			 */
+			const idAndOrg = await env.user_tokens.get(`${payload.salad_workload_id}|${req.saladOrg}`);
+			if (idAndOrg) {
+				const [id, org, project] = idAndOrg.split('|');
+				req.userId = id;
+				req.saladOrg = org;
+				req.saladProject = project;
+			} else {
+				/**
+				 * If we check to make sure the project exists and is valid.
+				 */
+				try {
+					await listContainerGroups(env, req.saladOrg, saladProject, true);
+					req.saladProject = saladProject;
+
+					/**
+					 * If everything is valid, we check to see if we have a user provisioned for this org already.
+					 */
+					const user = await getUserByUsername(env, req.saladOrg);
+					let userId: string | undefined;
+					if (user) {
+						userId = user.id;
+					} else {
+						userId = await createUser(env, req.saladOrg);
+					}
+
+					/**
+					 * Finally, we cache the user ID and organization for future requests. This token does not expire
+					 * because we validate the JWT on each request.
+					 */
+					req.userId = userId;
+					await env.user_tokens.put(`${payload.salad_workload_id}|${req.saladOrg}`, `${userId}|${req.saladOrg}|${saladProject}`);
+				} catch (err: any) {
+					return error(403, { error: 'Forbidden', message: `Invalid Project '${saladProject}': ${err.message}` });
+				}
+			}
+		} catch (err: any) {
+			return error(403, { error: 'Forbidden', message: err.message });
+		}
+	} else {
+		return error(401, { error: 'Unauthorized', message: 'API Key or Bearer Token Required' });
+	}
 	return;
 }
 
@@ -23,4 +139,89 @@ export async function adminOnly(req: AuthedRequest, env: Env) {
 		return error(403, { error: 'Forbidden', message: 'Admin Only' });
 	}
 	return;
+}
+
+export async function validateSaladApiKey(env: Env, apiKey: string, orgName: string): Promise<ApiKeyValidationResponse> {
+	if (!apiKey || !orgName) {
+		throw new Error('API Key and Organization Name Required');
+	}
+	const cacheKey = `${apiKey}:${orgName}`;
+	const cacheTtl = parseInt(env.TOKEN_CACHE_TTL);
+	const cached = await env.token_cache.get<ApiKeyValidationResponse>(cacheKey, {
+		type: 'json',
+		cacheTtl,
+	});
+
+	if (cached) {
+		return cached;
+	}
+
+	const response = await fetch(env.AUTH_URL, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Basic ${Buffer.from(`${env.SALAD_USERNAME}:${env.SALAD_PASSWORD}`).toString('base64')}`,
+		},
+		body: JSON.stringify({ api_key: apiKey, organization_name: orgName }),
+	});
+
+	if (!response.ok) {
+		console.error(await response.text());
+		throw new Error('Error Accessing Authentication Service');
+	}
+
+	const body = (await response.json()) as ApiKeyValidationResponse;
+
+	if (!body.is_api_key_valid) {
+		throw new Error('Invalid API Key');
+	}
+
+	if (!body.is_organization_name_valid) {
+		throw new Error('Invalid Organization Name');
+	}
+
+	if (!body.is_entitled) {
+		throw new Error('This organization is not entitled to use the Kelpie API');
+	}
+
+	await env.token_cache.put(cacheKey, JSON.stringify(body), {
+		expirationTtl: cacheTtl,
+	});
+
+	return body;
+}
+
+export async function getJWKs(env: Env): Promise<jose.JSONWebKeySet> {
+	const cacheKey = 'jwks';
+	const cacheTtl = parseInt(env.JWKS_CACHE_TTL);
+	const cached = await env.token_cache.get<jose.JSONWebKeySet>(cacheKey, {
+		type: 'json',
+		cacheTtl,
+	});
+	if (cached) {
+		return cached;
+	}
+
+	const response = await fetch(env.JWKS_URL);
+	if (!response.ok) {
+		console.error(await response.text());
+		throw new Error('Error Accessing JWKS');
+	}
+
+	const body = (await response.json()) as jose.JSONWebKeySet;
+
+	await env.token_cache.put(cacheKey, JSON.stringify(body), {
+		expirationTtl: cacheTtl,
+	});
+
+	return body;
+}
+
+export async function validateSaladJWT(env: Env, token: string): Promise<SaladJWTPayload> {
+	const jwksRaw = await getJWKs(env);
+	const jwks = jose.createLocalJWKSet(jwksRaw);
+
+	const { payload } = await jose.jwtVerify(token, jwks);
+
+	return payload as SaladJWTPayload;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -222,6 +222,8 @@ export async function validateSaladJWT(env: Env, token: string): Promise<SaladJW
 	const jwksRaw = await getJWKs(env);
 	const jwks = jose.createLocalJWKSet(jwksRaw);
 
+	const decoded = jose.decodeJwt(token);
+
 	const { payload } = await jose.jwtVerify(token, jwks);
 
 	return payload as SaladJWTPayload;

--- a/src/routes/jobs.test.ts
+++ b/src/routes/jobs.test.ts
@@ -1,5 +1,6 @@
 import { expect, it, describe, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import { adminToken, clearJobs, clearUsers, createUser } from '../utils/test';
+import { env } from 'cloudflare:test';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -106,6 +107,52 @@ describe('POST /jobs', () => {
 			],
 		});
 		expect(input_bucket).toBeUndefined();
+	});
+
+	it('Jobs submitted with an API key are picked up by workers with a JWT', async () => {
+		const response = await fetch('http://localhost:8787/jobs', {
+			method: 'POST',
+			headers: {
+				'Salad-Api-Key': env.TEST_API_KEY!,
+				'Content-Type': 'application/json',
+				'Salad-Organization': env.TEST_ORG!,
+				'Salad-Project': 'default',
+			},
+			body: JSON.stringify({
+				command: 'python',
+				arguments: ['/app/main.py'],
+				sync: {
+					before: [
+						{
+							bucket: 'testbucket',
+							prefix: 'before/',
+							local_path: '/app/before',
+							direction: 'download',
+						},
+					],
+				},
+				container_group_id: 'testgroup123',
+			}),
+		});
+
+		let body = await response.text();
+
+		expect(response.status).toEqual(202);
+
+		const job = JSON.parse(body) as any;
+		expect(job.id).toBeDefined();
+
+		const workResp = await fetch(`http://localhost:8787/work?machine_id=123&container_group_id=testgroup123`, {
+			headers: {
+				Authorization: `Bearer ${env.TEST_JWT}`,
+				'Salad-Project': 'default',
+			},
+		});
+
+		expect(workResp.status).toEqual(200);
+		const work = (await workResp.json()) as any[];
+		expect(work).toHaveLength(1);
+		expect(work[0].id).toEqual(job.id);
 	});
 });
 

--- a/src/routes/jobs.test.ts
+++ b/src/routes/jobs.test.ts
@@ -13,11 +13,6 @@ beforeAll(async () => {
 	token = t;
 });
 
-afterAll(async () => {
-	await clearJobs();
-	await clearUsers();
-});
-
 async function queueJob(overrides: any = {}) {
 	return fetch('http://localhost:8787/jobs', {
 		method: 'POST',

--- a/src/routes/jobs.ts
+++ b/src/routes/jobs.ts
@@ -186,7 +186,7 @@ export class CreateJob extends OpenAPIRoute {
 	static schema = {
 		summary: 'Queue a new job',
 		description: queueJobDocs,
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		requestBody: APIJobSubmissionSchema,
 		responses: {
 			'202': {
@@ -249,7 +249,7 @@ export class BatchCreateJobs extends OpenAPIRoute {
 	static schema = {
 		summary: 'Queue multiple jobs',
 		description: `Queue multiple jobs in one request. Limit 1000 jobs per request.\n\n${queueJobDocs}`,
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		requestBody: APIJobSubmissionSchema.array().min(1).max(1000),
 		responses: {
 			'202': {
@@ -317,7 +317,7 @@ export class GetJob extends OpenAPIRoute {
 	static schema = {
 		summary: 'Get a job',
 		description: 'Get a job by ID',
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		parameters: {
 			id: Path(String, { description: 'Job ID', required: true }),
 		},
@@ -381,7 +381,7 @@ export class GetWork extends OpenAPIRoute {
 	static schema = {
 		summary: 'Get work',
 		description: 'Get a job to work on',
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		parameters: {
 			machine_id: Query(String, { description: 'Machine ID', required: true }),
 			container_group_id: Query(String, { description: 'Container Group ID', required: true }),
@@ -454,7 +454,7 @@ export class JobHeartbeat extends OpenAPIRoute {
 	static schema = {
 		summary: 'Job heartbeat',
 		description: 'Update the heartbeat for a job',
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		parameters: {
 			id: Path(String, { description: 'Job ID', required: true }),
 		},
@@ -516,7 +516,7 @@ export class ReportJobFailure extends OpenAPIRoute {
 	static schema = {
 		summary: 'Report job failure',
 		description: 'Report a job failure',
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		parameters: {
 			id: Path(String, { description: 'Job ID', required: true }),
 		},
@@ -633,7 +633,7 @@ export class ReportJobCompleted extends OpenAPIRoute {
 	static schema = {
 		summary: 'Report job completed',
 		description: 'Report a job completed',
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		parameters: {
 			id: Path(String, { description: 'Job ID', required: true }),
 		},
@@ -691,7 +691,7 @@ export class CancelJob extends OpenAPIRoute {
 	static schema = {
 		summary: 'Cancel job',
 		description: 'Cancel a job',
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		parameters: {
 			id: Path(String, { description: 'Job ID', required: true }),
 		},
@@ -751,7 +751,7 @@ export class ListJobs extends OpenAPIRoute {
 	static schema = {
 		summary: 'List jobs',
 		description: 'List your jobs',
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		parameters: {
 			status: Query(
 				new Enumeration({ description: 'Job status', values: ['pending', 'running', 'completed', 'canceled', 'failed'], required: false })

--- a/src/routes/scaling-rules.test.ts
+++ b/src/routes/scaling-rules.test.ts
@@ -11,11 +11,6 @@ beforeAll(async () => {
 	token = t;
 });
 
-afterAll(async () => {
-	await clearUsers();
-	await clearScalingRules();
-});
-
 async function createScalingRule(overrides: any = {}): Promise<any> {
 	const rule = {
 		container_group_id: '014cfb51-fad8-4d9a-a058-68c24477f494',

--- a/src/routes/scaling-rules.test.ts
+++ b/src/routes/scaling-rules.test.ts
@@ -81,7 +81,7 @@ describe('PATCH /scaling-rules/:id', () => {
 		expect(updateResponse.status).toEqual(200);
 
 		const updatedRuleResponse = (await updateResponse.json()) as any;
-		expect(updatedRuleResponse).toMatchObject({ ...createdRule, ...updatedRule });
+		expect(updatedRuleResponse).toMatchObject({ ...createdRule, ...updatedRule, updated: updatedRuleResponse.updated });
 	});
 });
 

--- a/src/routes/scaling-rules.ts
+++ b/src/routes/scaling-rules.ts
@@ -20,7 +20,7 @@ export class CreateScalingRule extends OpenAPIRoute {
 	static schema = {
 		summary: 'Create a new scaling rule',
 		description: 'Create a new scaling rule',
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		requestBody: APIScalingRuleSchema,
 		responses: {
 			'201': {
@@ -90,7 +90,7 @@ export class UpdateScalingRule extends OpenAPIRoute {
 	static schema = {
 		summary: 'Update an existing scaling rule',
 		description: 'Update an existing scaling rule',
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		parameters: {
 			id: Path(String, { description: 'Container Group ID', required: true }),
 		},
@@ -152,7 +152,7 @@ export class ClearScalingRules extends OpenAPIRoute {
 	static schema = {
 		summary: '(ADMIN) Clear all scaling rules',
 		description: 'Clear all scaling rules',
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		responses: {
 			'204': {
 				description: 'Scaling rules cleared',
@@ -193,7 +193,7 @@ export class ListScalingRules extends OpenAPIRoute {
 	static schema = {
 		summary: 'List all scaling rules',
 		description: 'List all scaling rules',
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		responses: {
 			'200': {
 				description: 'Scaling rules listed',
@@ -239,7 +239,7 @@ export class GetScalingRule extends OpenAPIRoute {
 	static schema = {
 		summary: 'Get a scaling rule',
 		description: 'Get a scaling rule',
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		parameters: {
 			id: Path(String, { description: 'Container Group ID', required: true }),
 		},
@@ -292,7 +292,7 @@ export class DeleteScalingRule extends OpenAPIRoute {
 	static schema = {
 		summary: 'Delete a scaling rule',
 		description: 'Delete a scaling rule',
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		parameters: {
 			id: Path(String, { description: 'Container Group ID', required: true }),
 		},

--- a/src/routes/users.test.ts
+++ b/src/routes/users.test.ts
@@ -57,7 +57,7 @@ describe('POST /users/:id/token', () => {
 });
 
 describe('GET /users/me', () => {
-	it('Returns the current user from a kelpie api key', async () => {
+	it('Returns the current user from a Kelpie API Key', async () => {
 		const { user, token } = await createUser('testuser-get-me-kelpie');
 		const response = await fetch('http://localhost:8787/users/me', {
 			method: 'GET',
@@ -90,6 +90,23 @@ describe('GET /users/me', () => {
 
 		expect(response.status).toEqual(200);
 
+		const userResponse = JSON.parse(body) as any;
+		expect(userResponse.username).toEqual(env.TEST_ORG!);
+	});
+
+	it('Returns the current user from an IMDS JWT', async () => {
+		expect(env.TEST_JWT).toBeDefined();
+		expect(env.TEST_ORG).toBeDefined();
+		const response = await fetch('http://localhost:8787/users/me', {
+			method: 'GET',
+			headers: {
+				Authorization: `Bearer ${env.TEST_JWT!}`,
+				'Salad-Project': 'default',
+			},
+		});
+		const body = await response.text();
+
+		expect(response.status).toEqual(200);
 		const userResponse = JSON.parse(body) as any;
 		expect(userResponse.username).toEqual(env.TEST_ORG!);
 	});

--- a/src/routes/users.test.ts
+++ b/src/routes/users.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, describe, beforeAll, afterAll } from 'vitest';
-import { adminToken, clearUsers } from '../utils/test';
+import { adminToken, clearUsers, createUser } from '../utils/test';
 
 beforeAll(clearUsers);
 afterAll(clearUsers);
@@ -53,5 +53,35 @@ describe('POST /users/:id/token', () => {
 
 		const { token } = (await response.json()) as any;
 		expect(token).toBeDefined();
+	});
+});
+
+describe('GET /users/me', () => {
+	let user: any;
+	let token: string;
+	beforeAll(async () => {
+		await clearUsers();
+		const { user: u, token: t } = await createUser('testuser-jobs');
+		user = u;
+		token = t;
+	});
+
+	afterAll(async () => {
+		await clearUsers();
+	});
+	it('Returns the current user', async () => {
+		const response = await fetch('http://localhost:8787/users/me', {
+			method: 'GET',
+			headers: {
+				'X-Kelpie-Key': token,
+			},
+		});
+
+		const body = await response.text();
+
+		expect(response.status).toEqual(200);
+
+		const userResponse = JSON.parse(body) as any;
+		expect(userResponse).toMatchObject(user);
 	});
 });

--- a/src/routes/users.test.ts
+++ b/src/routes/users.test.ts
@@ -110,4 +110,37 @@ describe('GET /users/me', () => {
 		const userResponse = JSON.parse(body) as any;
 		expect(userResponse.username).toEqual(env.TEST_ORG!);
 	});
+
+	it('Returns the same user for jwt and api key if they match', async () => {
+		expect(env.TEST_API_KEY).toBeDefined();
+		expect(env.TEST_ORG).toBeDefined();
+		expect(env.TEST_JWT).toBeDefined();
+		const response1 = await fetch('http://localhost:8787/users/me', {
+			method: 'GET',
+			headers: {
+				Authorization: `Bearer ${env.TEST_JWT!}`,
+				'Salad-Project': 'default',
+			},
+		});
+
+		const body1 = await response1.text();
+		expect(response1.status).toEqual(200);
+		const userResponse1 = JSON.parse(body1) as any;
+		expect(userResponse1.username).toEqual(env.TEST_ORG!);
+
+		const response2 = await fetch('http://localhost:8787/users/me', {
+			method: 'GET',
+			headers: {
+				'Salad-Api-Key': env.TEST_API_KEY!,
+				'Salad-Organization': env.TEST_ORG!,
+				'Salad-Project': 'default',
+			},
+		});
+		const body2 = await response2.text();
+		expect(response2.status).toEqual(200);
+		const userResponse2 = JSON.parse(body2) as any;
+		expect(userResponse2.username).toEqual(env.TEST_ORG!);
+
+		expect(userResponse1.id).toEqual(userResponse2.id);
+	});
 });

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -7,7 +7,7 @@ export class CreateUser extends OpenAPIRoute {
 	static schema = {
 		summary: '(ADMIN) Create a new user',
 		description: 'Create a new user',
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		requestBody: {
 			username: String,
 		},
@@ -65,7 +65,7 @@ export class CreateToken extends OpenAPIRoute {
 	static schema = {
 		summary: '(ADMIN) Create a new token',
 		description: 'Create a new token',
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		parameters: {
 			id: Path(String, { description: 'User ID', required: true }),
 		},
@@ -180,7 +180,7 @@ export class GetUser extends OpenAPIRoute {
 	static schema = {
 		summary: 'Get the logged in user',
 		description: 'Get the logged in user',
-		security: [{ apiKey: [] }],
+		security: [{ apiKey: [], jwt: [], saladApiKey: [] }],
 		responses: {
 			'200': {
 				description: 'User found',

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,7 +1,7 @@
 import { OpenAPIRoute, Path } from '@cloudflare/itty-router-openapi';
 import { error } from '../utils/error';
 import { AuthedRequest, Env, UserResponseSchema } from '../types';
-import { createUser, getUserById, getUserByUsername, clearAllNonAdminUsers } from '../db/users';
+import { createUser, getUserById, getUserByUsername, clearAllNonAdminUsers, clearAllNonAdminUserTokens } from '../db/users';
 
 export class CreateUser extends OpenAPIRoute {
 	static schema = {
@@ -168,6 +168,7 @@ export class ClearUsers extends OpenAPIRoute {
 	async handle(request: AuthedRequest, env: Env, ctx: any) {
 		try {
 			await clearAllNonAdminUsers(env);
+			await clearAllNonAdminUserTokens(env);
 			return new Response(null, { status: 204 });
 		} catch (e: any) {
 			console.log(e);

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,6 +1,6 @@
 import { OpenAPIRoute, Path } from '@cloudflare/itty-router-openapi';
 import { error } from '../utils/error';
-import { AuthedRequest, Env } from '../types';
+import { AuthedRequest, Env, UserResponseSchema } from '../types';
 import { createUser, getUserById, getUserByUsername, clearAllNonAdminUsers } from '../db/users';
 
 export class CreateUser extends OpenAPIRoute {
@@ -169,6 +169,59 @@ export class ClearUsers extends OpenAPIRoute {
 		try {
 			await clearAllNonAdminUsers(env);
 			return new Response(null, { status: 204 });
+		} catch (e: any) {
+			console.log(e);
+			return error(500, { error: 'Internal server error', message: e.message });
+		}
+	}
+}
+
+export class GetUser extends OpenAPIRoute {
+	static schema = {
+		summary: 'Get the logged in user',
+		description: 'Get the logged in user',
+		security: [{ apiKey: [] }],
+		responses: {
+			'200': {
+				description: 'User found',
+				schema: UserResponseSchema,
+			},
+			'403': {
+				description: 'Forbidden',
+				schema: {
+					error: String,
+					message: String,
+				},
+			},
+			'404': {
+				description: 'User not found',
+				schema: {
+					error: String,
+					message: String,
+				},
+			},
+			'500': {
+				description: 'Internal server error',
+				schema: {
+					error: String,
+					message: String,
+				},
+			},
+		},
+	};
+	async handle(request: AuthedRequest, env: Env, ctx: any) {
+		if (!request.userId) {
+			// Theoretically, this should never happen because the middleware should always set userId
+			// but just in case, we return a 403 error.
+			console.log('User ID not found in request');
+			return error(403, { error: 'Forbidden', message: 'User not authenticated' });
+		}
+		try {
+			const user = await getUserById(env, request.userId);
+			if (!user) {
+				return error(404, { error: 'User not found', message: 'User not found' });
+			}
+			return user;
 		} catch (e: any) {
 			console.log(e);
 			return error(500, { error: 'Internal server error', message: e.message });

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,13 @@ export const APIScalingRuleResponseSchema = APIScalingRuleSchema.merge(
 	})
 );
 
+export const UserResponseSchema = z.object({
+	id: z.string().uuid(),
+	username: z.string(),
+	created: z.date(),
+});
+export type UserResponse = z.infer<typeof UserResponseSchema>;
+
 export interface AuthedRequest extends Request {
 	userId?: string;
 	saladOrg?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,10 @@ export interface Env {
 	token_cache: KVNamespace;
 
 	DB: D1Database;
+
+	TEST_API_KEY?: string;
+	TEST_ORG?: string;
+	TEST_ORG_ID?: string;
 }
 
 export const SaladDataSchema = z.object({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,22 @@
 import { z } from 'zod';
+import { JWTPayload } from 'jose';
 
 export interface Env {
 	API_HEADER: string;
 	MAX_FAILURES_PER_WORKER: string;
 	SALAD_API_KEY: string;
+	SALAD_PASSWORD: string;
 	ADMIN_ID: string;
+	AUTH_URL: string;
+	JWKS_URL: string;
+	TOKEN_CACHE_TTL: string;
+	JWKS_CACHE_TTL: string;
+	SALAD_USERNAME: string;
 
-	upload_tokens: KVNamespace;
-	download_tokens: KVNamespace;
 	user_tokens: KVNamespace;
 	banned_workers: KVNamespace;
 	salad_cache: KVNamespace;
+	token_cache: KVNamespace;
 
 	DB: D1Database;
 }
@@ -223,3 +229,19 @@ export type Instance = {
 export type InstanceList = {
 	instances: Instance[];
 };
+
+export interface ApiKeyValidationResponse {
+	is_api_key_valid: boolean;
+	is_organization_name_valid: boolean;
+	is_entitled: boolean;
+	organization_id: string;
+	organization_name: string;
+}
+
+export interface SaladJWTPayload extends JWTPayload {
+	salad_machine_id: string;
+	salad_organization_id: string;
+	salad_organization_name: string;
+	salad_workload_id: string;
+	salad_workload_name: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface Env {
 	TEST_API_KEY?: string;
 	TEST_ORG?: string;
 	TEST_ORG_ID?: string;
+	TEST_JWT?: string;
 }
 
 export const SaladDataSchema = z.object({


### PR DESCRIPTION
> **NOTE** the kelpie worker binary has not been updated to support these features yet.

- Instead of `X-Kelpie-Key` you can now use your salad api key, as well as the jwt issued by the instance metadata service.
- A user account with a username equal to your org name will be provisioned if it does not exist the first time you use a salad credential
- When using `Salad-Api-Key`, you must also include headers `Salad-Organization`, `Salad-Project`
- When using `Authorization: Bearer $Token` you must also include header `Salad-Project`
- Adds `GET /users/me` endpoint that returns the user object for the authenticated user. Useful for confirming that api key and jwt return the same user

resolves #16 