### PR TITLE
Better resiliency around accessing the Salad API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "kelpie-api",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kelpie-api",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "dependencies": {
         "@cloudflare/itty-router-openapi": "^1.0.10",
-        "jose": "5.9.6",
+        "jose": "5.10.0",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -1902,9 +1902,9 @@
       "license": "MIT"
     },
     "node_modules/jose": {
-      "version": "5.9.6",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
-      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kelpie-api",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/src/autoscale.ts
+++ b/src/autoscale.ts
@@ -7,9 +7,10 @@ export async function evaluateAllScalingRules(env: Env) {
 	const rules = await listScalingRules(env);
 	console.log(`Found ${rules.length} scaling rules`);
 
-	// Evaluate the rules batches of 5
-	for (let i = 0; i < rules.length; i += 5) {
-		await Promise.all(rules.slice(i, i + 5).map((rule) => evaluateScalingRule(env, rule)));
+	const maxConcurrentScalingRules = parseInt(env.MAX_CONCURRENT_SCALING_RULES) || 5;
+	// Evaluate the rules batches of maxConcurrentScalingRules
+	for (let i = 0; i < rules.length; i += maxConcurrentScalingRules) {
+		await Promise.all(rules.slice(i, i + maxConcurrentScalingRules).map((rule) => evaluateScalingRule(env, rule)));
 	}
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ export interface Env {
 	TOKEN_CACHE_TTL: string;
 	JWKS_CACHE_TTL: string;
 	SALAD_USERNAME: string;
+	MAX_CONCURRENT_SCALING_RULES: string;
+	MAX_SALAD_API_RETRIES: string;
 
 	user_tokens: KVNamespace;
 	banned_workers: KVNamespace;


### PR DESCRIPTION
- Adds 2 new configuration values
  - `MAX_CONCURRENT_SCALING_RULES` - how many scaling rules to evaluate at once. each scaling rule may involve multiple api calls to the Salad api
  - `MAX_SALAD_API_RETRIES` - All requests to the salad api are now wrapped with a retry, and an exponential backoff. This value sets how many retries to allow.