### PR TITLE
Auto cleanup deleted container groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kelpie-api",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kelpie-api",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "dependencies": {
         "@cloudflare/itty-router-openapi": "^1.0.10",
         "jose": "5.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kelpie-api",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/src/autoscale.ts
+++ b/src/autoscale.ts
@@ -47,6 +47,9 @@ export async function setReplicasForContainerGroup(
 	containerGroupName: string,
 	containerGroupID: string
 ) {
+	/**
+	 * This function returns null if it gets a 404 from the API
+	 */
 	const group = await getContainerGroupByName(env, orgName, projectName, containerGroupName);
 	if (!group) {
 		console.log(`Container group not found: ${orgName}/${projectName}/${containerGroupName}. Cleaning up scaling rule.`);

--- a/src/autoscale.ts
+++ b/src/autoscale.ts
@@ -1,5 +1,5 @@
 import { Env, DBScalingRule } from './types';
-import { listScalingRules } from './db/scaling-rules';
+import { listScalingRules, deleteScalingRuleByContainerGroupID } from './db/scaling-rules';
 import { countActiveAndRecentlyActiveJobsInContainerGroup } from './db/jobs';
 import { getContainerGroupByName, setContainerGroupReplicas, startContainerGroup, stopContainerGroup } from './utils/salad';
 
@@ -26,7 +26,14 @@ export async function evaluateScalingRule(env: Env, rule: DBScalingRule) {
 		console.log(
 			`Evaluating scaling rule ${rule.container_group_id} for container group ${rule.org_name}/${rule.project_name}/${rule.container_group_name}: ${numJobs} jobs, constrained to ${constrainedNumJobs} replicas`
 		);
-		await setReplicasForContainerGroup(env, constrainedNumJobs, rule.org_name, rule.project_name, rule.container_group_name);
+		await setReplicasForContainerGroup(
+			env,
+			constrainedNumJobs,
+			rule.org_name,
+			rule.project_name,
+			rule.container_group_name,
+			rule.container_group_id
+		);
 	} catch (error) {
 		console.error(`Error evaluating scaling rule ${rule.container_group_id}: ${error}`);
 	}
@@ -37,11 +44,13 @@ export async function setReplicasForContainerGroup(
 	numReplicas: number,
 	orgName: string,
 	projectName: string,
-	containerGroupName: string
+	containerGroupName: string,
+	containerGroupID: string
 ) {
 	const group = await getContainerGroupByName(env, orgName, projectName, containerGroupName);
 	if (!group) {
-		console.log(`Container group not found: ${orgName}/${projectName}/${containerGroupName}`);
+		console.log(`Container group not found: ${orgName}/${projectName}/${containerGroupName}. Cleaning up scaling rule.`);
+		await deleteScalingRuleByContainerGroupID(env, containerGroupID);
 		return;
 	}
 

--- a/src/utils/salad.ts
+++ b/src/utils/salad.ts
@@ -7,15 +7,19 @@ export function sleep(ms: number): Promise<void> {
 }
 
 export async function fetchWithRetries(url: string, options: RequestInit, retries: number = 3): Promise<Response> {
+	let response: Response | undefined;
 	for (let i = 0; i < retries; i++) {
-		const response = await fetch(url, options);
-		if (response.ok) {
+		response = await fetch(url, options);
+		if (response.ok || response.status === 404) {
 			return response;
 		}
 		console.log(`Fetch failed (attempt ${i + 1}): ${response.status}`);
 		await sleep(1000 * (i + 1));
 	}
-	throw new Error(`Failed to fetch ${url} after ${retries} attempts`);
+	if (response) {
+		return response;
+	}
+	throw new Error(`Did not receive response from API after ${retries} attempts`);
 }
 
 export async function listContainerGroups(env: Env, orgName: string, projectName: string, noCache = false): Promise<SaladContainerGroup[]> {


### PR DESCRIPTION
- we now short-circuit the retry loop on api requests if the response is a 404, the rationale being that if it doesn't exist, then we don't need to check again.
- As a first step of  setting the replica count, we make an api request to get the container group. previously we just returned if the container group was not found. now, we remove the associated scaling rule so that we don't check for it again in the future. This will reduce the load on the salad api from kelpie checking on non-existent container groups