### PR TITLE
Jobs submition with key

### DIFF
--- a/example-wrangler.toml
+++ b/example-wrangler.toml
@@ -16,7 +16,14 @@ crons = ["*/5 * * * *"] # * * * * * = run every 5 minutes
 API_HEADER = "x-kelpie-key"
 MAX_FAILURES_PER_WORKER = "5"
 ADMIN_ID = "00000000-0000-0000-0000-000000000000"
-
+TOKEN_CACHE_TTL = "60"
+JWKS_CACHE_TTL = "600"
+MAX_SALAD_API_RETRIES = "3"
+AUTH_URL=""
+JWKS_URL=""
+MAX_CONCURRENT_SCALING_RULES="4"
+MAX_FAILURES_PER_WORKER="3"
+SALAD_USERNAME=""
 
 # Bind a KV Namespace. Use KV as persistent storage for small key-value pairs.
 # Docs: https://developers.cloudflare.com/workers/runtime-apis/kv
@@ -30,6 +37,10 @@ id = "330b9fef-d0b3-4061-962c-9f1a038f488c"
 
 [[kv_namespaces]]
 binding = "salad_cache"
+id = "fea342ad-1262-4264-8fe9-57a9984204d7"
+
+[[kv_namespaces]]
+binding = "token_cache"
 id = "fea342ad-1262-4264-8fe9-57a9984204d7"
 
 [[d1_databases]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kelpie-api",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kelpie-api",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@cloudflare/itty-router-openapi": "^1.0.10",
         "jose": "5.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kelpie-api",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -49,7 +49,7 @@ export async function validateAuth(req: AuthedRequest, env: Env) {
 				req.saladOrg = payload.organization_name;
 				payload.organization_id;
 				try {
-					await listContainerGroups(env, req.saladOrg, saladProject, true);
+					await listContainerGroups(env, req.saladOrg, saladProject, true, saladApiKey);
 					req.saladProject = saladProject;
 					/**
 					 * If everything is valid, we check to see if we have a user provisioned for this org already.
@@ -102,7 +102,7 @@ export async function validateAuth(req: AuthedRequest, env: Env) {
 				 * If we check to make sure the project exists and is valid.
 				 */
 				try {
-					await listContainerGroups(env, req.saladOrg, saladProject, true);
+					await listContainerGroups(env, req.saladOrg, saladProject, true, saladApiKey);
 					req.saladProject = saladProject;
 
 					/**
@@ -182,7 +182,7 @@ export async function validateSaladApiKey(env: Env, apiKey: string, orgName: str
 	}
 
 	if (!body.is_entitled) {
-		throw new Error('This organization is not entitled to use the Kelpie API');
+		console.log(`Organization ${orgName} is not entitled to use the Kelpie API`);
 	}
 
 	await env.token_cache.put(cacheKey, JSON.stringify(body), {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -45,11 +45,14 @@ export async function validateAuth(req: AuthedRequest, env: Env) {
 			 * If we don't have a cached user ID, we need to validate the API Key.
 			 */
 			try {
-				const payload = await validateSaladApiKey(env, saladApiKey, saladOrg || '');
-				req.saladOrg = payload.organization_name;
-				payload.organization_id;
 				try {
-					await listContainerGroups(env, req.saladOrg, saladProject, true, saladApiKey);
+					const payload = await validateSaladApiKey(env, saladApiKey, saladOrg || '');
+					req.saladOrg = payload.organization_name;
+				} catch {
+					req.saladOrg = saladOrg;
+				}
+				try {
+					await listContainerGroups(env, req.saladOrg, saladProject, true, saladApiKey ?? undefined);
 					req.saladProject = saladProject;
 					/**
 					 * If everything is valid, we check to see if we have a user provisioned for this org already.
@@ -102,7 +105,7 @@ export async function validateAuth(req: AuthedRequest, env: Env) {
 				 * If we check to make sure the project exists and is valid.
 				 */
 				try {
-					await listContainerGroups(env, req.saladOrg, saladProject, true, saladApiKey);
+					await listContainerGroups(env, req.saladOrg, saladProject, true, saladApiKey ?? undefined);
 					req.saladProject = saladProject;
 
 					/**

--- a/src/utils/salad.ts
+++ b/src/utils/salad.ts
@@ -22,7 +22,7 @@ export async function fetchWithRetries(url: string, options: RequestInit, retrie
 	throw new Error(`Did not receive response from API after ${retries} attempts`);
 }
 
-export async function listContainerGroups(env: Env, orgName: string, projectName: string, noCache = false): Promise<SaladContainerGroup[]> {
+export async function listContainerGroups(env: Env, orgName: string, projectName: string, noCache = false, apiKey?: string): Promise<SaladContainerGroup[]> {
 	// Check to see if we cached the value already
 	if (!noCache) {
 		const cachedValue = await env.salad_cache.get(`${orgName}/${projectName}`);
@@ -35,7 +35,7 @@ export async function listContainerGroups(env: Env, orgName: string, projectName
 
 	// Fetch the container groups from Salad
 	const url = `${saladBaseUrl}/organizations/${orgName}/projects/${projectName}/containers`;
-	const response = await fetchWithRetries(url, { headers: { 'Salad-Api-Key': env.SALAD_API_KEY } }, maxRetries);
+	const response = await fetchWithRetries(url, { headers: { 'Salad-Api-Key': apiKey || env.SALAD_API_KEY } }, maxRetries);
 	if (!response.ok) {
 		console.log(`Failed to fetch container groups in project ${orgName}/${projectName}: ${response.status}`);
 		console.log(await response.text());


### PR DESCRIPTION
This pull request introduces minor improvements and bug fixes related to authentication and API entitlement checks, as well as updates to how API keys are handled when listing container groups. The changes enhance error logging, improve API key usage flexibility, and update the package version.

**Authentication and API key handling:**

* Updated `listContainerGroups` to accept an optional `apiKey` parameter, allowing dynamic selection of the API key instead of always using the environment variable. This change is reflected in both the function signature and its usage in `middleware.ts`. 

**Error handling and logging:**

* Improved entitlement check logic by replacing a thrown error with a console log when an organization is not entitled to use the Kelpie API, allowing for better visibility without interrupting execution.

**Version update:**

* Bumped the package version from `0.7.0` to `0.7.1` in `package.json` to reflect the new changes.